### PR TITLE
fix: 修复 F5 调试报错（无法直接启动类库项目、扩展未部署到实验实例）

### DIFF
--- a/DeepSeek_v4_for_VisualStudio.csproj
+++ b/DeepSeek_v4_for_VisualStudio.csproj
@@ -9,7 +9,9 @@
     <!-- VSIX settings -->
     <VSSDKBuildToolsAutoSetup>true</VSSDKBuildToolsAutoSetup>
     <GeneratePkgDefFile>true</GeneratePkgDefFile>
-    <StartProgram>C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\devenv.exe</StartProgram>
+    <DeployExtension Condition="'$(BuildingInsideVisualStudio)' == 'true'">true</DeployExtension>
+    <StartAction>Program</StartAction>
+    <StartProgram>$(DevEnvDir)devenv.exe</StartProgram>
     <StartArguments>/RootSuffix Exp</StartArguments>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes #50

## 问题

按 <kbd>F5</kbd> 调试扩展时，VS 报「无法直接启动带有类库输出类型的项目」；即使忽略该错误，实验实例的 <kbd>视图</kbd> → <kbd>其他窗口</kbd> 中也找不到 DeepSeek Chat，因为扩展从未被部署到实验实例。

## 根因

- VSIX 项目是类库输出类型，项目缺少 `<StartAction>Program</StartAction>`，VS 尝试直接启动项目而报错；
- VSSDK BuildTools 在 `VSSDKBuildToolsAutoSetup=true` 时默认 `DeployExtension=false`（见 Microsoft.VSSDK.BuildTools.targets），项目未显式开启，导致 VSIX 只打包、从不部署到实验实例；
- `StartProgram` 硬编码 Professional 版安装路径（`C:\Program Files\Microsoft Visual Studio\2022\Professional\Common7\IDE\devenv.exe`），不可移植。

## 修复

- 新增 `<DeployExtension Condition="'$(BuildingInsideVisualStudio)' == 'true'">true</DeployExtension>` —— 仅在 VS 内构建时启用 VSIX 部署，命令行构建（CI）不受影响；
- 新增 `<StartAction>Program</StartAction>` —— 以外部程序方式调试；
- `StartProgram` 改用 VS 内置属性 `$(DevEnvDir)` —— 自动解析当前 VS 安装路径，兼容 Community / Professional / Enterprise。

## 验证

<kbd>F5</kbd> 后输出窗口出现 VSIX 部署步骤（VSIX 约 955MB，解压部署约 1-2 分钟），部署完成后实验实例自动启动，可在 <kbd>视图</kbd> → <kbd>其他窗口</kbd> 中正常打开 DeepSeek Chat，且可正常命中断点调试。
