### PR TITLE
支持 ARM64 架构（amd64 + arm64 双架构）

### DIFF
--- a/.github/workflows/paddleocr-remove.patch
+++ b/.github/workflows/paddleocr-remove.patch
@@ -397,3 +397,17 @@ index e9e00a5..c4ac7dd 100644
 -        #endregion
      }
  }
+diff --git a/source.extension.vsixmanifest b/source.extension.vsixmanifest
+index 7d84386..e9db826 100644
+--- a/source.extension.vsixmanifest
++++ b/source.extension.vsixmanifest
+@@ -10,6 +10,9 @@
+     <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.14, )">
+       <ProductArchitecture>amd64</ProductArchitecture>
+     </InstallationTarget>
++    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.14, )">
++      <ProductArchitecture>arm64</ProductArchitecture>
++    </InstallationTarget>
+   </Installation>
+   <Dependencies>
+     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![VS](https://img.shields.io/badge/VS-2022%2017.14%2B-purple)]()
 [![.NET](https://img.shields.io/badge/.NET%20Framework-4.7.2-blueviolet)]()
 [![DeepSeek](https://img.shields.io/badge/DeepSeek-V4-green)]()
-[![Platform](https://img.shields.io/badge/platform-Windows%20x64-lightgrey)]()
+[![Platform](https://img.shields.io/badge/platform-Windows%20x64%20%2F%20ARM64-lightgrey)]()
 [![Version](https://img.shields.io/badge/version-1.1.15-blue)]()
 
 [English](README_EN.md)
@@ -55,6 +55,8 @@
 
 从 [Releases](https://github.com/zmy15/DeepSeek-v4-for-VisualStudio/releases) 下载最新 `.vsix`，关闭 Visual Studio 后双击安装。
 
+> **ARM64 支持**：扩展兼容 ARM64 版 Visual Studio（2022 17.14+ / 2026），也兼容 x64。注意：**本地 OCR（完整版）仅支持 x64**；ARM64 设备请使用 **No-Local-OCR** 版本（不含本地 OCR，其余功能完整）。
+
 ### 方式二：从源码编译
 
 ```powershell
@@ -67,7 +69,7 @@ git clone https://github.com/zmy15/DeepSeek-v4-for-VisualStudio.git
 | Visual Studio | 2022 (17.14+) |
 | .NET Framework | 4.7.2 SDK |
 | VS SDK | VS Installer → "Visual Studio 扩展开发" |
-| Windows | 10/11 x64 |
+| Windows | 10/11 x64 / ARM64 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,11 @@
 
 从 [Releases](https://github.com/zmy15/DeepSeek-v4-for-VisualStudio/releases) 下载最新 `.vsix`，关闭 Visual Studio 后双击安装。
 
-> **ARM64 支持**：扩展兼容 ARM64 版 Visual Studio（2022 17.14+ / 2026），也兼容 x64。注意：**本地 OCR（完整版）仅支持 x64**；ARM64 设备请使用 **No-Local-OCR** 版本（不含本地 OCR，其余功能完整）。
+> **架构支持**：
+> - **完整版（含本地 OCR）**：仅支持 **x64**（PaddleOCR / OpenCvSharp 原生库暂无 ARM64 版本）。
+> - **No-Local-OCR 版**：同时支持 **x64** 与 **ARM64**（含 ARM64 版 Visual Studio 2022 17.14+ / 2026）。
+>
+> ARM64 设备请下载 **No-Local-OCR** 版本（不含本地 OCR，其余功能完整）。
 
 ### 方式二：从源码编译
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -10,7 +10,7 @@
 [![VS](https://img.shields.io/badge/VS-2022%2017.14%2B-purple)]()
 [![.NET](https://img.shields.io/badge/.NET%20Framework-4.7.2-blueviolet)]()
 [![DeepSeek](https://img.shields.io/badge/DeepSeek-V4-green)]()
-[![Platform](https://img.shields.io/badge/platform-Windows%20x64-lightgrey)]()
+[![Platform](https://img.shields.io/badge/platform-Windows%20x64%20%2F%20ARM64-lightgrey)]()
 [![Version](https://img.shields.io/badge/version-1.1.15-blue)]()
 
 [中文](README.md)
@@ -55,6 +55,8 @@
 
 Download the latest `.vsix` from [Releases](https://github.com/zmy15/DeepSeek-v4-for-VisualStudio/releases), close Visual Studio, then double-click to install.
 
+> **ARM64 support**: The extension is compatible with both ARM64 and x64 builds of Visual Studio (2022 17.14+ / 2026). Note: **local OCR (full version) is x64-only**; on ARM64 devices, use the **No-Local-OCR** release (without local OCR, fully functional).
+
 ### Option 2: Build from Source
 
 ```powershell
@@ -67,7 +69,7 @@ git clone https://github.com/zmy15/DeepSeek-v4-for-VisualStudio.git
 | Visual Studio | 2022 (17.14+) |
 | .NET Framework | 4.7.2 SDK |
 | VS SDK | VS Installer → "Visual Studio extension development" |
-| Windows | 10/11 x64 |
+| Windows | 10/11 x64 / ARM64 |
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -55,7 +55,11 @@
 
 Download the latest `.vsix` from [Releases](https://github.com/zmy15/DeepSeek-v4-for-VisualStudio/releases), close Visual Studio, then double-click to install.
 
-> **ARM64 support**: The extension is compatible with both ARM64 and x64 builds of Visual Studio (2022 17.14+ / 2026). Note: **local OCR (full version) is x64-only**; on ARM64 devices, use the **No-Local-OCR** release (without local OCR, fully functional).
+> **Architecture support**:
+> - **Full version (with local OCR)**: **x64** only (PaddleOCR / OpenCvSharp native libraries have no ARM64 build yet).
+> - **No-Local-OCR release**: supports both **x64** and **ARM64** (including ARM64 builds of Visual Studio 2022 17.14+ / 2026).
+>
+> On ARM64 devices, download the **No-Local-OCR** release (without local OCR, fully functional otherwise).
 
 ### Option 2: Build from Source
 

--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -8,7 +8,7 @@
   </Metadata>
   <Installation>
     <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.14, )">
-      <ProductArchitecture>amd64,arm64</ProductArchitecture>
+      <ProductArchitecture>amd64</ProductArchitecture>
     </InstallationTarget>
   </Installation>
   <Dependencies>

--- a/source.extension.vsixmanifest
+++ b/source.extension.vsixmanifest
@@ -8,7 +8,7 @@
   </Metadata>
   <Installation>
     <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.14, )">
-      <ProductArchitecture>amd64</ProductArchitecture>
+      <ProductArchitecture>amd64,arm64</ProductArchitecture>
     </InstallationTarget>
   </Installation>
   <Dependencies>


### PR DESCRIPTION
## 概述

为扩展添加 **ARM64** 支持（resolves #53）。

## 变更内容

1. [`source.extension.vsixmanifest`](../blob/master/source.extension.vsixmanifest)：`<ProductArchitecture>` 由 `amd64` 改为 `amd64,arm64`，使扩展可在 x64 与 ARM64 版 Visual Studio（2022 17.14+ / 2026）上安装。
2. [README.md](../blob/master/README.md) / [README_EN.md](../blob/master/README_EN.md)：补充 ARM64 支持说明与编译依赖。

## 验证情况

- 环境：
  <table border="1" cellpadding="5">
  <thead>
  <tr>   <!-- 关键：必须用 tr 包裹 th -->
  <th>软件</th>
  <th colspan="2">版本</th>
  </tr>
  </thead>
  <tbody>
  <tr>
  <td>Visual Studio</td>
  <td colspan="2">18.9.2</td>
  </tr>
  <tr>
  <td rowspan="3">Windows</td>
  <td>版本</td>
  <td>Windows 11 家庭版</td>
  </tr>
  <tr>
  <td>版本号</td>
  <td>25H2</td>
  </tr>
  <tr>
  <td>系统类型</td>
  <td>64 位操作系统, 基于 ARM 的处理器</td>
  </tr>
  </tbody>
  </table>
- 原始 VSIX（`amd64`）在 ARM64 VS 安装失败：`VSIXInstaller.NoApplicableSKUsException`。
- 将清单架构改为 `arm64` 后重新打包，**安装成功**，扩展已在 devenv.exe（ARM64）中正常加载运行。
- 修改为 `amd64,arm64` 后通过 VSIXInstaller 校验。
- 说明：由于本机为 ARM64，**x64 安装需要维护者在 x64 环境做最终确认**（`amd64,arm64` 为 VSIX 多架构标准写法）。

## 注意事项

- **本地 OCR（完整版）仅支持 x64**：PaddleOCR / OpenCvSharp 原生库（`win64.mkl`）无 ARM64 版本。ARM64 用户请使用 **No-Local-OCR** 版本（无本地 OCR，其余功能完整）。
- 扩展主体为 AnyCPU 托管程序集，SkiaSharp 已内置 arm64 原生库，故 ARM64 可正常运行。
